### PR TITLE
Bug fix: Removed incorrect escaping of single quotes.

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -332,7 +332,6 @@ end
 function encodeString(s)
   s = string.gsub(s,'\\','\\\\')
   s = string.gsub(s,'"','\\"')
-  s = string.gsub(s,"'","\\'")
   s = string.gsub(s,'\n','\\n')
   s = string.gsub(s,'\t','\\t')
   return s 


### PR DESCRIPTION
The JSON spec requires double quotes for keys. This would cause issues with other standard compliant parsers. The list of valid characters after an escape code is `"\/bfnrtu` (see http://json.org/ for more): ![valid characters](http://json.org/string.gif)

A simple way to reproduce:

In lua:

```
require("json")
json.save("example.json", {["'"] = 0})
```

In the command line:

```
python -mjson.tool < example.json
```

Output:

```
Invalid \escape: line 1 column 3 (char 2)
```

This fix removes escaping for the single quote, which is not part of the JSON spec.
